### PR TITLE
Add gitignore travis.yml and setup.py + fix linux_test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+*~
+*.py[cod]
+
+.tox/
+.cache/
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: python
+sudo: false
+env:
+  - TOX_ENV=py27
+install:
+  - pip install tox
+script: tox -e $TOX_ENV

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python
+#
+# Copyright 2013 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Setup configuration."""
+
+try:
+    import setuptools
+except ImportError:
+    from ez_setup import use_setuptools
+    use_setuptools()
+    import setuptools
+
+
+setuptools.setup(
+    name='pyu2f',
+    version='HEAD',
+    description='U2F host library for interacting with a U2F device over USB.',
+    long_description='pyu2f is a python based U2F host library for Linux, '
+                     'Windows, and MacOS. It provides functionality for '
+                     'interacting with a U2F device over USB.',
+    url='https://github.com/google/pyu2f/',
+    author='Google Inc.',
+    author_email='pyu2f-team@google.com',
+    # Contained modules and scripts.
+    packages=setuptools.find_packages(),
+    install_requires=[],
+    tests_require=[
+        'unittest2>=0.5.1',
+        'pyfakefs>=2.4',
+        'mock>=1.0.1',
+    ],
+    include_package_data=True,
+    platforms=["Windows", "Linux", "OS X", "macOS"],
+    # PyPI package information.
+    classifiers=[
+        'License :: OSI Approved :: Apache Software License',
+        'Topic :: Software Development :: Libraries',
+        'Topic :: Software Development :: Libraries :: Python Modules',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
+    ],
+    license='Apache 2.0',
+    zip_safe=True,
+)

--- a/tests/hid/linux_test.py
+++ b/tests/hid/linux_test.py
@@ -71,9 +71,8 @@ class FakeDeviceOsModule(object):
 
 
 class LinuxTest(unittest.TestCase):
-  fs = fake_filesystem.FakeFilesystem()
-
   def setUp(self):
+    self.fs = fake_filesystem.FakeFilesystem()
     self.fs.CreateDirectory('/sys/class/hidraw')
 
   def tearDown(self):
@@ -87,6 +86,7 @@ class LinuxTest(unittest.TestCase):
       fake_open = fake_filesystem.FakeFileOpen(self.fs)
       with mock.patch.object(__builtin__, 'open', fake_open):
         devs = list(linux.LinuxHidDevice.Enumerate())
+        devs = sorted(devs, key=lambda(k):(k['vendor_id']))
 
         self.assertEquals(len(devs), 2)
         self.assertEquals(devs[0]['vendor_id'], 0x046d)


### PR DESCRIPTION
- gitignore helps us ignore compiled files and tox test envs.
- .travis.yml will be used by travis to run Continuous Integration
  tests on new pull requests.
- setup.py will be used to later integrate the lib to pip. Other tools
  will then be able to depend on this lib and have dependencies
  automatically pulled in.
- while adding the tests, I noticed that linux_test was failing. The
  order of the dev listing was probably undetermined. Fixed by sorting
  the list. Also moved the fs initialization to setup to make sure there
  are no leaks between tests.