### PR TITLE
Fix warnings about assertEquals

### DIFF
--- a/pyu2f/tests/customauthenticator_test.py
+++ b/pyu2f/tests/customauthenticator_test.py
@@ -122,44 +122,44 @@ class CustomAuthenticatorTest(unittest.TestCase):
 
     self.assertTrue(mock_communicate_method.called)
     communicate_args = mock_communicate_method.call_args[0]
-    self.assertEquals(len(communicate_args), 1,
-                      'communicate() should have been called with two args')
+    self.assertEqual(len(communicate_args), 1,
+                     'communicate() should have been called with two args')
 
     communicate_stdin = communicate_args[0]
     communicate_json_len_le = communicate_stdin[:4]
     communicate_json_len = struct.unpack('<I', communicate_json_len_le)[0]
     communicate_json = communicate_stdin[4:]
-    self.assertEquals(len(communicate_json), communicate_json_len,
-                      'communicate() should have been called with correct'
-                      'length field')
+    self.assertEqual(len(communicate_json), communicate_json_len,
+                     'communicate() should have been called with correct'
+                     'length field')
 
     communicate_dict = json.loads(communicate_json.decode("utf8"))
-    self.assertEquals(communicate_dict.get('type'), 'sign_helper_request')
-    self.assertEquals(communicate_dict.get('timeoutSeconds'), 5)
-    self.assertEquals(communicate_dict.get('localAlways'), True)
+    self.assertEqual(communicate_dict.get('type'), 'sign_helper_request')
+    self.assertEqual(communicate_dict.get('timeoutSeconds'), 5)
+    self.assertEqual(communicate_dict.get('localAlways'), True)
     challenges = communicate_dict.get('signData')
 
     # Validate Challenge portion of plugin request
     self.assertIsNotNone(challenges)
-    self.assertEquals(len(challenges), 1)
+    self.assertEqual(len(challenges), 1)
     challenge = challenges[0]
-    self.assertEquals(challenge.get('appIdHash'),
-                      SIGN_SUCCESS['app_id_hash_encoded'])
-    self.assertEquals(challenge.get('challengeHash'),
-                      SIGN_SUCCESS['challenge_hash_encoded'])
-    self.assertEquals(challenge.get('keyHandle'),
-                      SIGN_SUCCESS['key_handle_encoded'])
-    self.assertEquals(challenge.get('version'),
-                      SIGN_SUCCESS['u2f_version'])
+    self.assertEqual(challenge.get('appIdHash'),
+                     SIGN_SUCCESS['app_id_hash_encoded'])
+    self.assertEqual(challenge.get('challengeHash'),
+                     SIGN_SUCCESS['challenge_hash_encoded'])
+    self.assertEqual(challenge.get('keyHandle'),
+                     SIGN_SUCCESS['key_handle_encoded'])
+    self.assertEqual(challenge.get('version'),
+                     SIGN_SUCCESS['u2f_version'])
 
     mock_wait_method.assert_called_with()
 
     # Validate Authenticate() response
-    self.assertEquals(result['applicationId'], SIGN_SUCCESS['app_id'])
-    self.assertEquals(result['clientData'], SIGN_SUCCESS['client_data_encoded'])
-    self.assertEquals(result['keyHandle'], SIGN_SUCCESS['key_handle_encoded'])
-    self.assertEquals(result['signatureData'],
-                      SIGN_SUCCESS['signature_data_encoded'])
+    self.assertEqual(result['applicationId'], SIGN_SUCCESS['app_id'])
+    self.assertEqual(result['clientData'], SIGN_SUCCESS['client_data_encoded'])
+    self.assertEqual(result['keyHandle'], SIGN_SUCCESS['key_handle_encoded'])
+    self.assertEqual(result['signatureData'],
+                     SIGN_SUCCESS['signature_data_encoded'])
 
   @mock.patch.object(customauthenticator.subprocess, 'Popen')
   @mock.patch.object(customauthenticator.os.environ, 'get',
@@ -323,7 +323,7 @@ class CustomAuthenticatorTest(unittest.TestCase):
 
     with self.assertRaises(errors.U2FError) as cm:
       authenticator.Authenticate(SIGN_SUCCESS['app_id'], challenge_data)
-    self.assertEquals(cm.exception.code, errors.U2FError.TIMEOUT)
+    self.assertEqual(cm.exception.code, errors.U2FError.TIMEOUT)
 
   @mock.patch.object(customauthenticator.subprocess, 'Popen')
   @mock.patch.object(customauthenticator.os.environ, 'get',
@@ -369,7 +369,7 @@ class CustomAuthenticatorTest(unittest.TestCase):
 
     with self.assertRaises(errors.U2FError) as cm:
       authenticator.Authenticate(SIGN_SUCCESS['app_id'], challenge_data)
-    self.assertEquals(cm.exception.code, errors.U2FError.DEVICE_INELIGIBLE)
+    self.assertEqual(cm.exception.code, errors.U2FError.DEVICE_INELIGIBLE)
 
 
 if __name__ == '__main__':

--- a/pyu2f/tests/hardware_test.py
+++ b/pyu2f/tests/hardware_test.py
@@ -60,11 +60,11 @@ class HardwareTest(unittest.TestCase):
         [0x01, 0x02, 0x90, 0x00])
 
     reply = sk.CmdRegister(challenge_param, app_param)
-    self.assertEquals(reply, bytearray([0x01, 0x02]))
-    self.assertEquals(mock_transport.SendMsgBytes.call_count, 1)
+    self.assertEqual(reply, bytearray([0x01, 0x02]))
+    self.assertEqual(mock_transport.SendMsgBytes.call_count, 1)
     (sent_msg,), _ = mock_transport.SendMsgBytes.call_args
-    self.assertEquals(sent_msg[0:4], bytearray([0x00, 0x01, 0x03, 0x00]))
-    self.assertEquals(sent_msg[7:-2], bytearray(challenge_param + app_param))
+    self.assertEqual(sent_msg[0:4], bytearray([0x00, 0x01, 0x03, 0x00]))
+    self.assertEqual(sent_msg[7:-2], bytearray(challenge_param + app_param))
 
   def testRegisterTUPRequired(self):
     mock_transport = mock.MagicMock()
@@ -77,7 +77,7 @@ class HardwareTest(unittest.TestCase):
 
     self.assertRaises(errors.TUPRequiredError, sk.CmdRegister, challenge_param,
                       app_param)
-    self.assertEquals(mock_transport.SendMsgBytes.call_count, 1)
+    self.assertEqual(mock_transport.SendMsgBytes.call_count, 1)
 
   def testVersion(self):
     mock_transport = mock.MagicMock()
@@ -86,10 +86,10 @@ class HardwareTest(unittest.TestCase):
     mock_transport.SendMsgBytes.return_value = bytearray(b'U2F_V2\x90\x00')
 
     reply = sk.CmdVersion()
-    self.assertEquals(reply, bytearray(b'U2F_V2'))
-    self.assertEquals(mock_transport.SendMsgBytes.call_count, 1)
+    self.assertEqual(reply, bytearray(b'U2F_V2'))
+    self.assertEqual(mock_transport.SendMsgBytes.call_count, 1)
     (sent_msg,), _ = mock_transport.SendMsgBytes.call_args
-    self.assertEquals(sent_msg, bytearray(
+    self.assertEqual(sent_msg, bytearray(
         [0x00, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00]))
 
   def testVersionFallback(self):
@@ -101,17 +101,17 @@ class HardwareTest(unittest.TestCase):
         bytearray(b'U2F_V2\x90\x00')]
 
     reply = sk.CmdVersion()
-    self.assertEquals(reply, bytearray(b'U2F_V2'))
-    self.assertEquals(mock_transport.SendMsgBytes.call_count, 2)
+    self.assertEqual(reply, bytearray(b'U2F_V2'))
+    self.assertEqual(mock_transport.SendMsgBytes.call_count, 2)
     (sent_msg,), _ = mock_transport.SendMsgBytes.call_args_list[0]
-    self.assertEquals(len(sent_msg), 7)
-    self.assertEquals(sent_msg[0:4], bytearray([0x00, 0x03, 0x00, 0x00]))
-    self.assertEquals(sent_msg[4:7], bytearray([0x00, 0x00, 0x00]))  # Le
+    self.assertEqual(len(sent_msg), 7)
+    self.assertEqual(sent_msg[0:4], bytearray([0x00, 0x03, 0x00, 0x00]))
+    self.assertEqual(sent_msg[4:7], bytearray([0x00, 0x00, 0x00]))  # Le
     (sent_msg,), _ = mock_transport.SendMsgBytes.call_args_list[1]
-    self.assertEquals(len(sent_msg), 9)
-    self.assertEquals(sent_msg[0:4], bytearray([0x00, 0x03, 0x00, 0x00]))
-    self.assertEquals(sent_msg[4:7], bytearray([0x00, 0x00, 0x00]))  # Lc
-    self.assertEquals(sent_msg[7:9], bytearray([0x00, 0x00]))  # Le
+    self.assertEqual(len(sent_msg), 9)
+    self.assertEqual(sent_msg[0:4], bytearray([0x00, 0x03, 0x00, 0x00]))
+    self.assertEqual(sent_msg[4:7], bytearray([0x00, 0x00, 0x00]))  # Lc
+    self.assertEqual(sent_msg[7:9], bytearray([0x00, 0x00]))  # Le
 
   def testVersionErrors(self):
     mock_transport = mock.MagicMock()
@@ -120,7 +120,7 @@ class HardwareTest(unittest.TestCase):
     mock_transport.SendMsgBytes.return_value = bytearray([0xfa, 0x05])
 
     self.assertRaises(errors.ApduError, sk.CmdVersion)
-    self.assertEquals(mock_transport.SendMsgBytes.call_count, 1)
+    self.assertEqual(mock_transport.SendMsgBytes.call_count, 1)
 
   def testAuthenticateSuccess(self):
     mock_transport = mock.MagicMock()
@@ -134,11 +134,11 @@ class HardwareTest(unittest.TestCase):
         [0x01, 0x02, 0x90, 0x00])
 
     reply = sk.CmdAuthenticate(challenge_param, app_param, key_handle)
-    self.assertEquals(reply, bytearray([0x01, 0x02]))
-    self.assertEquals(mock_transport.SendMsgBytes.call_count, 1)
+    self.assertEqual(reply, bytearray([0x01, 0x02]))
+    self.assertEqual(mock_transport.SendMsgBytes.call_count, 1)
     (sent_msg,), _ = mock_transport.SendMsgBytes.call_args
-    self.assertEquals(sent_msg[0:4], bytearray([0x00, 0x02, 0x03, 0x00]))
-    self.assertEquals(
+    self.assertEqual(sent_msg[0:4], bytearray([0x00, 0x02, 0x03, 0x00]))
+    self.assertEqual(
         sent_msg[7:-2],
         bytearray(challenge_param + app_param + bytearray([4, 1, 2, 3, 4])))
 
@@ -157,11 +157,11 @@ class HardwareTest(unittest.TestCase):
                                app_param,
                                key_handle,
                                check_only=True)
-    self.assertEquals(reply, bytearray([0x01, 0x02]))
-    self.assertEquals(mock_transport.SendMsgBytes.call_count, 1)
+    self.assertEqual(reply, bytearray([0x01, 0x02]))
+    self.assertEqual(mock_transport.SendMsgBytes.call_count, 1)
     (sent_msg,), _ = mock_transport.SendMsgBytes.call_args
-    self.assertEquals(sent_msg[0:4], bytearray([0x00, 0x02, 0x07, 0x00]))
-    self.assertEquals(
+    self.assertEqual(sent_msg[0:4], bytearray([0x00, 0x02, 0x07, 0x00]))
+    self.assertEqual(
         sent_msg[7:-2],
         bytearray(challenge_param + app_param + bytearray([4, 1, 2, 3, 4])))
 
@@ -177,7 +177,7 @@ class HardwareTest(unittest.TestCase):
 
     self.assertRaises(errors.TUPRequiredError, sk.CmdAuthenticate,
                       challenge_param, app_param, key_handle)
-    self.assertEquals(mock_transport.SendMsgBytes.call_count, 1)
+    self.assertEqual(mock_transport.SendMsgBytes.call_count, 1)
 
   def testAuthenticateInvalidKeyHandle(self):
     mock_transport = mock.MagicMock()
@@ -191,7 +191,7 @@ class HardwareTest(unittest.TestCase):
 
     self.assertRaises(errors.InvalidKeyHandleError, sk.CmdAuthenticate,
                       challenge_param, app_param, key_handle)
-    self.assertEquals(mock_transport.SendMsgBytes.call_count, 1)
+    self.assertEqual(mock_transport.SendMsgBytes.call_count, 1)
 
 
 if __name__ == '__main__':

--- a/pyu2f/tests/hid/linux_test.py
+++ b/pyu2f/tests/hid/linux_test.py
@@ -94,13 +94,13 @@ class LinuxTest(unittest.TestCase):
         devs = list(linux.LinuxHidDevice.Enumerate())
         devs = sorted(devs, key=lambda k: (k['vendor_id']))
 
-        self.assertEquals(len(devs), 2)
-        self.assertEquals(devs[0]['vendor_id'], 0x046d)
-        self.assertEquals(devs[0]['product_id'], 0x0c31c)
-        self.assertEquals(devs[1]['vendor_id'], 0x1050)
-        self.assertEquals(devs[1]['product_id'], 0x0407)
-        self.assertEquals(devs[1]['usage_page'], 0xf1d0)
-        self.assertEquals(devs[1]['usage'], 1)
+        self.assertEqual(len(devs), 2)
+        self.assertEqual(devs[0]['vendor_id'], 0x046d)
+        self.assertEqual(devs[0]['product_id'], 0x0c31c)
+        self.assertEqual(devs[1]['vendor_id'], 0x1050)
+        self.assertEqual(devs[1]['product_id'], 0x0407)
+        self.assertEqual(devs[1]['usage_page'], 0xf1d0)
+        self.assertEqual(devs[1]['usage'], 1)
 
   def testCallOpen(self):
     AddDevice(self.fs, 'hidraw1', 'Yubico U2F', 0x1050, 0x0407, YUBICO_RD)
@@ -112,17 +112,17 @@ class LinuxTest(unittest.TestCase):
       fake_dev_os = FakeDeviceOsModule()
       with mock.patch.object(linux, 'os', fake_dev_os):
         dev = linux.LinuxHidDevice('/dev/hidraw1')
-        self.assertEquals(dev.GetInReportDataLength(), 64)
-        self.assertEquals(dev.GetOutReportDataLength(), 64)
+        self.assertEqual(dev.GetInReportDataLength(), 64)
+        self.assertEqual(dev.GetOutReportDataLength(), 64)
 
         dev.Write(list(range(0, 64)))
         # The HidDevice implementation prepends a zero-byte representing the
         # report ID
-        self.assertEquals(list(fake_dev_os.data_written),
-                          [0] + list(range(0, 64)))
+        self.assertEqual(list(fake_dev_os.data_written),
+                         [0] + list(range(0, 64)))
 
         fake_dev_os.data_to_return = b'x' * 64
-        self.assertEquals(dev.Read(), [120] * 64)  # chr(120) = 'x'
+        self.assertEqual(dev.Read(), [120] * 64)  # chr(120) = 'x'
 
 
 if __name__ == '__main__':

--- a/pyu2f/tests/hid/macos_test.py
+++ b/pyu2f/tests/hid/macos_test.py
@@ -57,8 +57,8 @@ class MacOsTest(unittest.TestCase):
 
     device = macos.MacOsHidDevice('fakepath')
 
-    self.assertEquals(64, device.GetInReportDataLength())
-    self.assertEquals(64, device.GetOutReportDataLength())
+    self.assertEqual(64, device.GetInReportDataLength())
+    self.assertEqual(64, device.GetOutReportDataLength())
 
   @mock.patch.object(macos.threading, 'Thread')
   @mock.patch.multiple(macos, iokit=mock.DEFAULT, cf=mock.DEFAULT,
@@ -81,11 +81,11 @@ class MacOsTest(unittest.TestCase):
     self.assertIsNotNone(set_report_call_args)
 
     set_report_call_pos_args = iokit.IOHIDDeviceSetReport.call_args[0]
-    self.assertEquals(len(set_report_call_pos_args), 5)
-    self.assertEquals(set_report_call_pos_args[0], 'handle')
-    self.assertEquals(set_report_call_pos_args[1], 1)
-    self.assertEquals(set_report_call_pos_args[2], 0)
-    self.assertEquals(set_report_call_pos_args[4], 64)
+    self.assertEqual(len(set_report_call_pos_args), 5)
+    self.assertEqual(set_report_call_pos_args[0], 'handle')
+    self.assertEqual(set_report_call_pos_args[1], 1)
+    self.assertEqual(set_report_call_pos_args[2], 0)
+    self.assertEqual(set_report_call_pos_args[4], 64)
 
     report_buffer = set_report_call_pos_args[3]
     self.assertEqual(len(report_buffer), 64)
@@ -131,8 +131,8 @@ class MacOsTest(unittest.TestCase):
 
     # Device read should return the callback data
     read_result = device.Read()
-    self.assertEquals(read_result, list(range(64)), 'Read data should match '
-                      'data passed into the callback')
+    self.assertEqual(read_result, list(range(64)), 'Read data should match '
+                     'data passed into the callback')
 
 
 if __name__ == '__main__':

--- a/pyu2f/tests/hidtransport_test.py
+++ b/pyu2f/tests/hidtransport_test.py
@@ -89,12 +89,12 @@ class DiscoveryTest(unittest.TestCase):
         # Force the iterator into a list
         devs = list(hidtransport.DiscoverLocalHIDU2FDevices())
 
-        self.assertEquals(hid_mock.Enumerate.call_count, 1)
-        self.assertEquals(hid_mock.Open.call_count, 2)
-        self.assertEquals(len(devs), 2)
+        self.assertEqual(hid_mock.Enumerate.call_count, 1)
+        self.assertEqual(hid_mock.Open.call_count, 2)
+        self.assertEqual(len(devs), 2)
 
-        self.assertEquals(devs[0].hid_device.path, 'path3')
-        self.assertEquals(devs[1].hid_device.path, 'path4')
+        self.assertEqual(devs[0].hid_device.path, 'path3')
+        self.assertEqual(devs[1].hid_device.path, 'path4')
 
 
 class TransportTest(unittest.TestCase):
@@ -102,15 +102,15 @@ class TransportTest(unittest.TestCase):
   def testInit(self):
     fake_hid_dev = util.FakeHidDevice(bytearray([0x00, 0x00, 0x00, 0x01]))
     t = hidtransport.UsbHidTransport(fake_hid_dev)
-    self.assertEquals(t.cid, bytearray([0x00, 0x00, 0x00, 0x01]))
-    self.assertEquals(t.u2fhid_version, 0x01)
+    self.assertEqual(t.cid, bytearray([0x00, 0x00, 0x00, 0x01]))
+    self.assertEqual(t.u2fhid_version, 0x01)
 
   def testPing(self):
     fake_hid_dev = util.FakeHidDevice(bytearray([0x00, 0x00, 0x00, 0x01]))
     t = hidtransport.UsbHidTransport(fake_hid_dev)
 
     reply = t.SendPing(b'1234')
-    self.assertEquals(reply, b'1234')
+    self.assertEqual(reply, b'1234')
 
   def testMsg(self):
     fake_hid_dev = util.FakeHidDevice(
@@ -118,7 +118,7 @@ class TransportTest(unittest.TestCase):
     t = hidtransport.UsbHidTransport(fake_hid_dev)
 
     reply = t.SendMsgBytes([0x00, 0x01, 0x00, 0x00])
-    self.assertEquals(reply, bytearray([0x01, 0x90, 0x00]))
+    self.assertEqual(reply, bytearray([0x01, 0x90, 0x00]))
 
   def testMsgBusy(self):
     fake_hid_dev = util.FakeHidDevice(
@@ -133,7 +133,7 @@ class TransportTest(unittest.TestCase):
                               [0x00, 0x01, 0x00, 0x00])
 
       reply = t.SendMsgBytes([0x00, 0x01, 0x00, 0x00])
-      self.assertEquals(reply, bytearray([0x01, 0x90, 0x00]))
+      self.assertEqual(reply, bytearray([0x01, 0x90, 0x00]))
 
   def testFragmentedResponseMsg(self):
     body = bytearray([x % 256 for x in range(0, 1000)])
@@ -142,7 +142,7 @@ class TransportTest(unittest.TestCase):
 
     reply = t.SendMsgBytes([0x00, 0x01, 0x00, 0x00])
     # Confirm we properly reassemble the message
-    self.assertEquals(reply, bytearray(x % 256 for x in range(0, 1000)))
+    self.assertEqual(reply, bytearray(x % 256 for x in range(0, 1000)))
 
   def testFragmentedSendApdu(self):
     body = bytearray(x % 256 for x in range(0, 1000))
@@ -151,36 +151,36 @@ class TransportTest(unittest.TestCase):
     t = hidtransport.UsbHidTransport(fake_hid_dev)
 
     reply = t.SendMsgBytes(body)
-    self.assertEquals(reply, bytearray([0x90, 0x00]))
+    self.assertEqual(reply, bytearray([0x90, 0x00]))
     # 1 init packet from creating transport, 18 packets to send
     # the fragmented message
-    self.assertEquals(len(fake_hid_dev.received_packets), 18)
+    self.assertEqual(len(fake_hid_dev.received_packets), 18)
 
   def testInitPacketShape(self):
     packet = hidtransport.UsbHidTransport.InitPacket(
         64, bytearray(b'\x00\x00\x00\x01'), 0x83, 2, bytearray(b'\x01\x02'))
 
-    self.assertEquals(packet.ToWireFormat(), RPad(
+    self.assertEqual(packet.ToWireFormat(), RPad(
         [0, 0, 0, 1, 0x83, 0, 2, 1, 2], 64))
 
     copy = hidtransport.UsbHidTransport.InitPacket.FromWireFormat(
         64, packet.ToWireFormat())
-    self.assertEquals(copy.cid, bytearray(b'\x00\x00\x00\x01'))
-    self.assertEquals(copy.cmd, 0x83)
-    self.assertEquals(copy.size, 2)
-    self.assertEquals(copy.payload, bytearray(b'\x01\x02'))
+    self.assertEqual(copy.cid, bytearray(b'\x00\x00\x00\x01'))
+    self.assertEqual(copy.cmd, 0x83)
+    self.assertEqual(copy.size, 2)
+    self.assertEqual(copy.payload, bytearray(b'\x01\x02'))
 
   def testContPacketShape(self):
     packet = hidtransport.UsbHidTransport.ContPacket(
         64, bytearray(b'\x00\x00\x00\x01'), 5, bytearray(b'\x01\x02'))
 
-    self.assertEquals(packet.ToWireFormat(), RPad([0, 0, 0, 1, 5, 1, 2], 64))
+    self.assertEqual(packet.ToWireFormat(), RPad([0, 0, 0, 1, 5, 1, 2], 64))
 
     copy = hidtransport.UsbHidTransport.ContPacket.FromWireFormat(
         64, packet.ToWireFormat())
-    self.assertEquals(copy.cid, bytearray(b'\x00\x00\x00\x01'))
-    self.assertEquals(copy.seq, 5)
-    self.assertEquals(copy.payload, RPad(bytearray(b'\x01\x02'), 59))
+    self.assertEqual(copy.cid, bytearray(b'\x00\x00\x00\x01'))
+    self.assertEqual(copy.seq, 5)
+    self.assertEqual(copy.payload, RPad(bytearray(b'\x01\x02'), 59))
 
 
 if __name__ == '__main__':

--- a/pyu2f/tests/localauthenticator_test.py
+++ b/pyu2f/tests/localauthenticator_test.py
@@ -92,14 +92,14 @@ class LocalAuthenticatorTest(unittest.TestCase):
     self.assertEqual(registered_keys[0], SIGN_SUCCESS['registered_key'])
 
     # Validate authenticator response
-    self.assertEquals(response.get('clientData'),
-                      SIGN_SUCCESS['client_data_encoded'])
-    self.assertEquals(response.get('signatureData'),
-                      SIGN_SUCCESS['signature_data_encoded'])
-    self.assertEquals(response.get('applicationId'),
-                      SIGN_SUCCESS['app_id'])
-    self.assertEquals(response.get('keyHandle'),
-                      SIGN_SUCCESS['key_handle_encoded'])
+    self.assertEqual(response.get('clientData'),
+                     SIGN_SUCCESS['client_data_encoded'])
+    self.assertEqual(response.get('signatureData'),
+                     SIGN_SUCCESS['signature_data_encoded'])
+    self.assertEqual(response.get('applicationId'),
+                     SIGN_SUCCESS['app_id'])
+    self.assertEqual(response.get('keyHandle'),
+                     SIGN_SUCCESS['key_handle_encoded'])
 
   @mock.patch.object(localauthenticator.u2f, 'GetLocalU2FInterface')
   def testSignMultipleIneligible(self, mock_get_u2f_method):
@@ -125,7 +125,7 @@ class LocalAuthenticatorTest(unittest.TestCase):
       authenticator.Authenticate(SIGN_SUCCESS['app_id'],
                                  challenge_data)
 
-    self.assertEquals(cm.exception.code, errors.U2FError.DEVICE_INELIGIBLE)
+    self.assertEqual(cm.exception.code, errors.U2FError.DEVICE_INELIGIBLE)
 
   @mock.patch.object(localauthenticator.u2f, 'GetLocalU2FInterface')
   def testSignMultipleSuccess(self, mock_get_u2f_method):
@@ -168,14 +168,14 @@ class LocalAuthenticatorTest(unittest.TestCase):
     self.assertEqual(registered_keys[0], SIGN_SUCCESS['registered_key'])
 
     # Validate authenticator response
-    self.assertEquals(response.get('clientData'),
-                      SIGN_SUCCESS['client_data_encoded'])
-    self.assertEquals(response.get('signatureData'),
-                      SIGN_SUCCESS['signature_data_encoded'])
-    self.assertEquals(response.get('applicationId'),
-                      SIGN_SUCCESS['app_id'])
-    self.assertEquals(response.get('keyHandle'),
-                      SIGN_SUCCESS['key_handle_encoded'])
+    self.assertEqual(response.get('clientData'),
+                     SIGN_SUCCESS['client_data_encoded'])
+    self.assertEqual(response.get('signatureData'),
+                     SIGN_SUCCESS['signature_data_encoded'])
+    self.assertEqual(response.get('applicationId'),
+                     SIGN_SUCCESS['app_id'])
+    self.assertEqual(response.get('keyHandle'),
+                     SIGN_SUCCESS['key_handle_encoded'])
 
 
 if __name__ == '__main__':

--- a/pyu2f/tests/model_test.py
+++ b/pyu2f/tests/model_test.py
@@ -32,19 +32,19 @@ class ModelTest(unittest.TestCase):
     cd = model.ClientData(model.ClientData.TYP_REGISTRATION, b'ABCD',
                           'somemachine')
     obj = json.loads(cd.GetJson())
-    self.assertEquals(len(list(obj.keys())), 3)
-    self.assertEquals(obj['typ'], model.ClientData.TYP_REGISTRATION)
-    self.assertEquals(obj['challenge'], 'QUJDRA')
-    self.assertEquals(obj['origin'], 'somemachine')
+    self.assertEqual(len(list(obj.keys())), 3)
+    self.assertEqual(obj['typ'], model.ClientData.TYP_REGISTRATION)
+    self.assertEqual(obj['challenge'], 'QUJDRA')
+    self.assertEqual(obj['origin'], 'somemachine')
 
   def testClientDataAuth(self):
     cd = model.ClientData(model.ClientData.TYP_AUTHENTICATION, b'ABCD',
                           'somemachine')
     obj = json.loads(cd.GetJson())
-    self.assertEquals(len(list(obj.keys())), 3)
-    self.assertEquals(obj['typ'], model.ClientData.TYP_AUTHENTICATION)
-    self.assertEquals(obj['challenge'], 'QUJDRA')
-    self.assertEquals(obj['origin'], 'somemachine')
+    self.assertEqual(len(list(obj.keys())), 3)
+    self.assertEqual(obj['typ'], model.ClientData.TYP_AUTHENTICATION)
+    self.assertEqual(obj['challenge'], 'QUJDRA')
+    self.assertEqual(obj['origin'], 'somemachine')
 
   def testClientDataInvalid(self):
     self.assertRaises(errors.InvalidModelError, model.ClientData, 'foobar',

--- a/pyu2f/tests/u2f_test.py
+++ b/pyu2f/tests/u2f_test.py
@@ -38,11 +38,11 @@ class U2fTest(unittest.TestCase):
     u2f_api = u2f.U2FInterface(mock_sk)
 
     resp = u2f_api.Register('testapp', b'ABCD', [])
-    self.assertEquals(mock_sk.CmdRegister.call_count, 2)
-    self.assertEquals(mock_sk.CmdWink.call_count, 1)
-    self.assertEquals(resp.client_data.raw_server_challenge, b'ABCD')
-    self.assertEquals(resp.client_data.typ, 'navigator.id.finishEnrollment')
-    self.assertEquals(resp.registration_data, 'regdata')
+    self.assertEqual(mock_sk.CmdRegister.call_count, 2)
+    self.assertEqual(mock_sk.CmdWink.call_count, 1)
+    self.assertEqual(resp.client_data.raw_server_challenge, b'ABCD')
+    self.assertEqual(resp.client_data.typ, 'navigator.id.finishEnrollment')
+    self.assertEqual(resp.registration_data, 'regdata')
 
   def testRegisterSuccessWithPreviousKeys(self):
     mock_sk = mock.MagicMock()
@@ -53,15 +53,15 @@ class U2fTest(unittest.TestCase):
     u2f_api = u2f.U2FInterface(mock_sk)
 
     resp = u2f_api.Register('testapp', b'ABCD', [model.RegisteredKey('khA')])
-    self.assertEquals(mock_sk.CmdAuthenticate.call_count, 1)
+    self.assertEqual(mock_sk.CmdAuthenticate.call_count, 1)
     # Should be "Check only"
     self.assertTrue(mock_sk.CmdAuthenticate.call_args[0][3])
 
-    self.assertEquals(mock_sk.CmdRegister.call_count, 2)
-    self.assertEquals(mock_sk.CmdWink.call_count, 1)
-    self.assertEquals(resp.client_data.raw_server_challenge, b'ABCD')
-    self.assertEquals(resp.client_data.typ, 'navigator.id.finishEnrollment')
-    self.assertEquals(resp.registration_data, 'regdata')
+    self.assertEqual(mock_sk.CmdRegister.call_count, 2)
+    self.assertEqual(mock_sk.CmdWink.call_count, 1)
+    self.assertEqual(resp.client_data.raw_server_challenge, b'ABCD')
+    self.assertEqual(resp.client_data.typ, 'navigator.id.finishEnrollment')
+    self.assertEqual(resp.registration_data, 'regdata')
 
   def testRegisterFailAlreadyRegistered(self):
     mock_sk = mock.MagicMock()
@@ -72,14 +72,14 @@ class U2fTest(unittest.TestCase):
 
     with self.assertRaises(errors.U2FError) as cm:
       u2f_api.Register('testapp', b'ABCD', [model.RegisteredKey('khA')])
-    self.assertEquals(cm.exception.code, errors.U2FError.DEVICE_INELIGIBLE)
+    self.assertEqual(cm.exception.code, errors.U2FError.DEVICE_INELIGIBLE)
 
-    self.assertEquals(mock_sk.CmdAuthenticate.call_count, 1)
+    self.assertEqual(mock_sk.CmdAuthenticate.call_count, 1)
     # Should be "Check only"
     self.assertTrue(mock_sk.CmdAuthenticate.call_args[0][3])
 
-    self.assertEquals(mock_sk.CmdRegister.call_count, 0)
-    self.assertEquals(mock_sk.CmdWink.call_count, 0)
+    self.assertEqual(mock_sk.CmdRegister.call_count, 0)
+    self.assertEqual(mock_sk.CmdWink.call_count, 0)
 
   def testRegisterTimeout(self):
     mock_sk = mock.MagicMock()
@@ -91,9 +91,9 @@ class U2fTest(unittest.TestCase):
     with mock.patch.object(u2f, 'time') as _:
       with self.assertRaises(errors.U2FError) as cm:
         u2f_api.Register('testapp', b'ABCD', [])
-    self.assertEquals(cm.exception.code, errors.U2FError.TIMEOUT)
-    self.assertEquals(mock_sk.CmdRegister.call_count, 30)
-    self.assertEquals(mock_sk.CmdWink.call_count, 30)
+    self.assertEqual(cm.exception.code, errors.U2FError.TIMEOUT)
+    self.assertEqual(mock_sk.CmdRegister.call_count, 30)
+    self.assertEqual(mock_sk.CmdWink.call_count, 30)
 
   def testRegisterError(self):
     mock_sk = mock.MagicMock()
@@ -103,12 +103,12 @@ class U2fTest(unittest.TestCase):
 
     with self.assertRaises(errors.U2FError) as cm:
       u2f_api.Register('testapp', b'ABCD', [])
-    self.assertEquals(cm.exception.code, errors.U2FError.BAD_REQUEST)
-    self.assertEquals(cm.exception.cause.sw1, 0xff)
-    self.assertEquals(cm.exception.cause.sw2, 0xff)
+    self.assertEqual(cm.exception.code, errors.U2FError.BAD_REQUEST)
+    self.assertEqual(cm.exception.cause.sw1, 0xff)
+    self.assertEqual(cm.exception.cause.sw2, 0xff)
 
-    self.assertEquals(mock_sk.CmdRegister.call_count, 1)
-    self.assertEquals(mock_sk.CmdWink.call_count, 0)
+    self.assertEqual(mock_sk.CmdRegister.call_count, 1)
+    self.assertEqual(mock_sk.CmdWink.call_count, 0)
 
   def testAuthenticateSuccessWithTUP(self):
     mock_sk = mock.MagicMock()
@@ -119,12 +119,12 @@ class U2fTest(unittest.TestCase):
 
     resp = u2f_api.Authenticate('testapp', b'ABCD',
                                 [model.RegisteredKey('khA')])
-    self.assertEquals(mock_sk.CmdAuthenticate.call_count, 2)
-    self.assertEquals(mock_sk.CmdWink.call_count, 1)
-    self.assertEquals(resp.key_handle, 'khA')
-    self.assertEquals(resp.client_data.raw_server_challenge, b'ABCD')
-    self.assertEquals(resp.client_data.typ, 'navigator.id.getAssertion')
-    self.assertEquals(resp.signature_data, 'signature')
+    self.assertEqual(mock_sk.CmdAuthenticate.call_count, 2)
+    self.assertEqual(mock_sk.CmdWink.call_count, 1)
+    self.assertEqual(resp.key_handle, 'khA')
+    self.assertEqual(resp.client_data.raw_server_challenge, b'ABCD')
+    self.assertEqual(resp.client_data.typ, 'navigator.id.getAssertion')
+    self.assertEqual(resp.signature_data, 'signature')
 
   def testAuthenticateSuccessSkipInvalidKey(self):
     mock_sk = mock.MagicMock()
@@ -137,12 +137,12 @@ class U2fTest(unittest.TestCase):
     resp = u2f_api.Authenticate(
         'testapp', b'ABCD',
         [model.RegisteredKey('khA'), model.RegisteredKey('khB')])
-    self.assertEquals(mock_sk.CmdAuthenticate.call_count, 2)
-    self.assertEquals(mock_sk.CmdWink.call_count, 0)
-    self.assertEquals(resp.key_handle, 'khB')
-    self.assertEquals(resp.client_data.raw_server_challenge, b'ABCD')
-    self.assertEquals(resp.client_data.typ, 'navigator.id.getAssertion')
-    self.assertEquals(resp.signature_data, 'signature')
+    self.assertEqual(mock_sk.CmdAuthenticate.call_count, 2)
+    self.assertEqual(mock_sk.CmdWink.call_count, 0)
+    self.assertEqual(resp.key_handle, 'khB')
+    self.assertEqual(resp.client_data.raw_server_challenge, b'ABCD')
+    self.assertEqual(resp.client_data.typ, 'navigator.id.getAssertion')
+    self.assertEqual(resp.signature_data, 'signature')
 
   def testAuthenticateSuccessSkipInvalidVersion(self):
     mock_sk = mock.MagicMock()
@@ -156,12 +156,12 @@ class U2fTest(unittest.TestCase):
                                 [model.RegisteredKey('khA',
                                                      version='U2F_V3'),
                                  model.RegisteredKey('khB')])
-    self.assertEquals(mock_sk.CmdAuthenticate.call_count, 1)
-    self.assertEquals(mock_sk.CmdWink.call_count, 0)
-    self.assertEquals(resp.key_handle, 'khB')
-    self.assertEquals(resp.client_data.raw_server_challenge, b'ABCD')
-    self.assertEquals(resp.client_data.typ, 'navigator.id.getAssertion')
-    self.assertEquals(resp.signature_data, 'signature')
+    self.assertEqual(mock_sk.CmdAuthenticate.call_count, 1)
+    self.assertEqual(mock_sk.CmdWink.call_count, 0)
+    self.assertEqual(resp.key_handle, 'khB')
+    self.assertEqual(resp.client_data.raw_server_challenge, b'ABCD')
+    self.assertEqual(resp.client_data.typ, 'navigator.id.getAssertion')
+    self.assertEqual(resp.signature_data, 'signature')
 
   def testAuthenticateTimeout(self):
     mock_sk = mock.MagicMock()
@@ -173,9 +173,9 @@ class U2fTest(unittest.TestCase):
     with mock.patch.object(u2f, 'time') as _:
       with self.assertRaises(errors.U2FError) as cm:
         u2f_api.Authenticate('testapp', b'ABCD', [model.RegisteredKey('khA')])
-    self.assertEquals(cm.exception.code, errors.U2FError.TIMEOUT)
-    self.assertEquals(mock_sk.CmdAuthenticate.call_count, 30)
-    self.assertEquals(mock_sk.CmdWink.call_count, 30)
+    self.assertEqual(cm.exception.code, errors.U2FError.TIMEOUT)
+    self.assertEqual(mock_sk.CmdAuthenticate.call_count, 30)
+    self.assertEqual(mock_sk.CmdWink.call_count, 30)
 
   def testAuthenticateAllKeysInvalid(self):
     mock_sk = mock.MagicMock()
@@ -187,7 +187,7 @@ class U2fTest(unittest.TestCase):
       u2f_api.Authenticate('testapp', b'ABCD',
                            [model.RegisteredKey('khA'),
                             model.RegisteredKey('khB')])
-    self.assertEquals(cm.exception.code, errors.U2FError.DEVICE_INELIGIBLE)
+    self.assertEqual(cm.exception.code, errors.U2FError.DEVICE_INELIGIBLE)
 
     u2f_api = u2f.U2FInterface(mock_sk)
 
@@ -199,12 +199,12 @@ class U2fTest(unittest.TestCase):
 
     with self.assertRaises(errors.U2FError) as cm:
       u2f_api.Authenticate('testapp', b'ABCD', [model.RegisteredKey('khA')])
-    self.assertEquals(cm.exception.code, errors.U2FError.BAD_REQUEST)
-    self.assertEquals(cm.exception.cause.sw1, 0xff)
-    self.assertEquals(cm.exception.cause.sw2, 0xff)
+    self.assertEqual(cm.exception.code, errors.U2FError.BAD_REQUEST)
+    self.assertEqual(cm.exception.cause.sw1, 0xff)
+    self.assertEqual(cm.exception.cause.sw2, 0xff)
 
-    self.assertEquals(mock_sk.CmdAuthenticate.call_count, 1)
-    self.assertEquals(mock_sk.CmdWink.call_count, 0)
+    self.assertEqual(mock_sk.CmdAuthenticate.call_count, 1)
+    self.assertEqual(mock_sk.CmdWink.call_count, 0)
 
 
 if __name__ == '__main__':

--- a/pyu2f/tests/util_test.py
+++ b/pyu2f/tests/util_test.py
@@ -30,7 +30,7 @@ class UtilTest(unittest.TestCase):
   def testSimplePing(self):
     dev = util.FakeHidDevice(cid_to_allocate=None)
     dev.Write([0, 0, 0, 1, 0x81, 0, 3, 1, 2, 3])
-    self.assertEquals(
+    self.assertEqual(
         dev.Read(), [0, 0, 0, 1, 0x81, 0, 3, 1, 2, 3] + [0
                                                          for _ in range(54)])
 
@@ -38,13 +38,13 @@ class UtilTest(unittest.TestCase):
     dev = util.FakeHidDevice(cid_to_allocate=None)
     dev.SetChannelBusyCount(2)
     dev.Write([0, 0, 0, 1, 0x81, 0, 3, 1, 2, 3])
-    self.assertEquals(
+    self.assertEqual(
         dev.Read(), [0, 0, 0, 1, 0xbf, 0, 1, 6] + [0 for _ in range(56)])
     dev.Write([0, 0, 0, 1, 0x81, 0, 3, 1, 2, 3])
-    self.assertEquals(
+    self.assertEqual(
         dev.Read(), [0, 0, 0, 1, 0xbf, 0, 1, 6] + [0 for _ in range(56)])
     dev.Write([0, 0, 0, 1, 0x81, 0, 3, 1, 2, 3])
-    self.assertEquals(
+    self.assertEqual(
         dev.Read(), [0, 0, 0, 1, 0x81, 0, 3, 1, 2, 3] + [0
                                                          for _ in range(54)])
 
@@ -53,9 +53,9 @@ class UtilTest(unittest.TestCase):
                              msg_reply=list(range(85, 0, -1)))
     dev.Write([0, 0, 0, 1, 0x83, 0, 100] + [x for x in range(57)])
     dev.Write([0, 0, 0, 1, 0] + [x for x in range(57, 100)])
-    self.assertEquals(
+    self.assertEqual(
         dev.Read(), [0, 0, 0, 1, 0x83, 0, 85] + [x for x in range(85, 28, -1)])
-    self.assertEquals(
+    self.assertEqual(
         dev.Read(),
         [0, 0, 0, 1, 0] + [x for x in range(28, 0, -1)] + [0
                                                            for _ in range(31)])


### PR DESCRIPTION
Example:
```
pyu2f/tests/hid/macos_test.py::MacOsTest::testInitHidDevice
  /build/python-pyu2f/src/pyu2f-0.1.5/pyu2f/tests/hid/macos_test.py:61: DeprecationWarning: Please use assertEqual instead.
    self.assertEquals(64, device.GetOutReportDataLength())
```